### PR TITLE
Escape double quotes in string values

### DIFF
--- a/json-viewer/jquery.json-viewer.js
+++ b/json-viewer/jquery.json-viewer.js
@@ -46,6 +46,8 @@
       if (options.withLinks && isUrl(json)) {
         html += '<a href="' + json + '" class="json-string" target="_blank">' + json + '</a>';
       } else {
+        // Escape double quotes in the rendered non-URL string.
+        json = json.replace(/&quot;/g, '\\&quot;');
         html += '<span class="json-string">"' + json + '"</span>';
       }
     } else if (typeof json === 'number') {


### PR DESCRIPTION
This change will add a backslash to double quotes inside non-URL strings.
Before:
```
{
  "key": ""value""
}
```
After:
```
{
  "key": "\"value\""
}
```