### PR TITLE
fix display of big number objects to not add collapsable marker

### DIFF
--- a/json-viewer/jquery.json-viewer.js
+++ b/json-viewer/jquery.json-viewer.js
@@ -7,15 +7,18 @@
 
   /**
    * Check if arg is either an array with at least 1 element, or a dict with at least 1 key
+   * @param {*} arg Value to check
+   * @param {boolean} ignoreObj Flag set to true if an object shall be ignored and not marked as collapsable
    * @return boolean
    */
-  function isCollapsable(arg) {
-    return arg instanceof Object && Object.keys(arg).length > 0;
+  function isCollapsable(arg, ignoreObj) {
+    return arg instanceof Object && Object.keys(arg).length > 0 && !ignoreObj;
   }
 
   /**
    * Check if a string looks like a URL, based on protocol
    * This doesn't attempt to validate URLs, there's no use and syntax can be too complex
+   * @param {string} string String to check if it starts with a protocol definition
    * @return boolean
    */
   function isUrl(string) {
@@ -68,8 +71,9 @@
         html += '[<ol class="json-array">';
         for (var i = 0; i < json.length; ++i) {
           html += '<li>';
-          // Add toggle button if item is collapsable
-          if (isCollapsable(json[i])) {
+          // Add toggle button if item is collapsable and not a big number
+          var ignoreItem = (options.bigNumbers && (typeof json[key].toExponential === 'function' || json[key].isLosslessNumber));
+          if (isCollapsable(json[i], ignoreItem)) {
             html += '<a href class="json-toggle"></a>';
           }
           html += json2html(json[i], options);
@@ -100,8 +104,9 @@
                 '<span class="json-string">"' + key + '"</span>' : key;
 
               html += '<li>';
-              // Add toggle button if item is collapsable
-              if (isCollapsable(json[key])) {
+              // Add toggle button if item is collapsable and not a big number
+              var ignoreKey = (options.bigNumbers && (typeof json[key].toExponential === 'function' || json[key].isLosslessNumber));
+              if (isCollapsable(json[key], ignoreKey)) {
                 html += '<a href class="json-toggle">' + keyRepr + '</a>';
               } else {
                 html += keyRepr;


### PR DESCRIPTION
Using the big number libraries with the new support to display them directly i realized the current implementation shows the "collapsable" marker in front of the big numbers. But as this is useless for these numbers this patch removes them for this speacial case (bigNumbers support is activated and it is such a number)

This is the current state of display
![big_numbers_old](https://user-images.githubusercontent.com/5168949/169384292-95e54a73-3ba6-4efe-9492-b2eb4a36b178.png)

And this is the new one with this patch and `options.bigNumbers=true`
![big_numbers_new](https://user-images.githubusercontent.com/5168949/169384343-9dce3f30-45fb-44c4-a995-56f939a598f2.png)

