### PR TITLE
fix a bug: when the key changed by the function `htmlEscape(key)`, json[key] will get null

### DIFF
--- a/json-viewer/jquery.json-viewer.js
+++ b/json-viewer/jquery.json-viewer.js
@@ -95,18 +95,20 @@
           html += '{<ul class="json-dict">';
           for (var key in json) {
             if (Object.prototype.hasOwnProperty.call(json, key)) {
+              // define a parameter of the json value first to prevent get null from key when the key changed by the function `htmlEscape(key)`
+              let jsonElement = json[key];
               key = htmlEscape(key);
               var keyRepr = options.withQuotes ?
                 '<span class="json-string">"' + key + '"</span>' : key;
 
               html += '<li>';
               // Add toggle button if item is collapsable
-              if (isCollapsable(json[key])) {
+              if (isCollapsable(jsonElement)) {
                 html += '<a href class="json-toggle">' + keyRepr + '</a>';
               } else {
                 html += keyRepr;
               }
-              html += ': ' + json2html(json[key], options);
+              html += ': ' + json2html(jsonElement, options);
               // Add comma if item is not last
               if (--keyCount > 0) {
                 html += ',';


### PR DESCRIPTION
fix a bug: when the key changed by the function `htmlEscape(key)`, json[key] will get null

for example：
the json str is `{"<d":1}`
the result is 
```
{
<d: 
}
```
because the key changed after the function `htmlEscape`，the behind code `json[key]` get nothing 